### PR TITLE
Fix TypeScript type definitions #2

### DIFF
--- a/type-definitions/snabbdom-to-html.d.ts
+++ b/type-definitions/snabbdom-to-html.d.ts
@@ -41,7 +41,7 @@ declare module "snabbdom-to-html/modules/class" {
   export = classModule;
 }
 
-declare module "snabbdom-to-html-modules/props" {
+declare module "snabbdom-to-html/modules/props" {
   let propsModule: Module;
   export = propsModule;
 }

--- a/type-definitions/snabbdom-to-html.d.ts
+++ b/type-definitions/snabbdom-to-html.d.ts
@@ -1,7 +1,7 @@
 import {VNode} from "snabbdom";
 
 export interface Module {
-  (vnode: VNode, attributes: Map<string, string>): void;
+  (vnode: VNode, attributes: Map<string, number | string>): void;
 }
 
 declare module "snabbdom-to-html" {

--- a/type-definitions/snabbdom-to-html.d.ts
+++ b/type-definitions/snabbdom-to-html.d.ts
@@ -5,11 +5,13 @@ export interface Module {
 }
 
 declare module "snabbdom-to-html" {
-  export default function toHTML(vnode: VNode): string;
+  function toHTML(vnode: VNode): string;
+  export = toHTML
 }
 
 declare module "snabbdom-to-html/init" {
-  export default function init (modules: Module[]): (vnode: VNode) => string;
+  function init (modules: Module[]): (vnode: VNode) => string;
+  export = init
 }
 
 export interface ModuleIndex {
@@ -38,7 +40,6 @@ declare module "snabbdom-to-html/modules/class" {
   let classModule: Module;
   export = classModule;
 }
-
 
 declare module "snabbdom-to-html-modules/props" {
   let propsModule: Module;


### PR DESCRIPTION
@acstll, @TylorS: here are the changes needed to work with this library from typescript. After updating the type definitions, I can use the library with no problems (aside from Snabbdom VNode definition).

To learn how this works internally I have "rewritten" (mostly copy pasting and adding types) the library in typescript. You can found the source in this [branch](https://github.com/alvivi/snabbdom-to-html/tree/typescript-rewrite). The tests are passing. I added review notes to my code (You can find these searching for 'REVIEW'). Maybe you can use this version to compare itself with your future typescript-written version or something similar.
