### PR TITLE
Remove ES6 string interpolation from style module

### DIFF
--- a/modules/style.js
+++ b/modules/style.js
@@ -18,7 +18,7 @@ module.exports = function styleModule (vnode, attributes) {
   forOwn(style, function (value, key) {
     // omit hook objects
     if (typeof value === 'string' || typeof value === 'number') {
-      values.push(`${kebabCase(key)}: ${escape(value)}`)
+      values.push(kebabCase(key)+':'+escape(value))
     }
   })
 


### PR DESCRIPTION
I've got some problems with systemjs builder unable to parse style module when uglifying. 

It is due to use of ES6 string interpolation, I change to string concatenation to be ES5 compatible.