### PR TITLE
remove typings field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.0.0",
   "description": "Render Snabbdom Vnodes to HTML strings",
   "main": "index.js",
-  "typings": "./type-definitions/snabbdom-to-html.d.ts",
   "scripts": {
     "pretest": "standard",
     "test": "tape test/*.js",


### PR DESCRIPTION
`./type-definitions/snabbdom-to-html.d.ts` is broken.

```
node_modules/snabbdom-to-html/type-definitions/snabbdom-to-html.d.ts(9,3): error TS2666: Exports and export assignments are not permitted in module aug
mentations.
```