### PR TITLE
Fix SVG <text> tags self closing

### DIFF
--- a/elements.js
+++ b/elements.js
@@ -14,6 +14,7 @@ exports.CONTAINER = {
   'svg': true,
   'switch': true,
   'symbol': true,
+  'text': true,
 
   // http://www.w3.org/TR/SVG/intro.html#TermDescriptiveElement
   'desc': true,

--- a/test/index.js
+++ b/test/index.js
@@ -184,6 +184,12 @@ test('Modules', function (t) {
   ])
   t.equal(renderToString(vnode), html, 'svg')
 
+  html = '<svg><text>Hello world</text></svg>'
+  vnode = h('svg', [
+    h('text', 'Hello world')
+  ])
+  t.equal(renderToString(vnode), html, 'svg')
+
   vnode = h('label', {
     props: {
       htmlFor: 'beep'


### PR DESCRIPTION
Previously, `h('svg', [ h('text', 'Hello world') ])` would produce `<svg><text /></svg>`.

This change means it correctly produces `<svg><text>Hello world</text></svg>`.

😺 

I added test coverage and verified that it passes with the change in place and fails without.