### PR TITLE
Escape HTML in the text content

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,4 +1,5 @@
 
+var escape = require('lodash.escape')
 var parseSelector = require('parse-sel')
 var VOID_ELEMENTS = require('./elements').VOID
 var CONTAINER_ELEMENTS = require('./elements').CONTAINER
@@ -30,7 +31,7 @@ module.exports = function init (modules) {
     }
 
     if (!vnode.sel && vnode.text) {
-      return vnode.text
+      return escape(vnode.text)
     }
 
     vnode.data = vnode.data || {}
@@ -68,7 +69,7 @@ module.exports = function init (modules) {
       if (vnode.data.props && vnode.data.props.innerHTML) {
         tag.push(vnode.data.props.innerHTML)
       } else if (vnode.text) {
-        tag.push(vnode.text)
+        tag.push(escape(vnode.text))
       } else if (vnode.children) {
         vnode.children.forEach(function (child) {
           tag.push(renderToString(child))

--- a/test/index.js
+++ b/test/index.js
@@ -279,3 +279,15 @@ test('Custom CSS properties', function (t) {
 
   t.end()
 })
+
+test('Escape HTML in the text content', function (t) {
+  var vnode = h('div', ['<p></p>'])
+
+  t.equal(toHTML(vnode), '<div>&lt;p&gt;&lt;/p&gt;</div>')
+
+  vnode = h('div', '<p></p>')
+
+  t.equal(toHTML(vnode), '<div>&lt;p&gt;&lt;/p&gt;</div>')
+
+  t.end()
+})


### PR DESCRIPTION
An issue I've noticed recently:

```js
const html = toHTML(h('div', '<p></p>'));
console.log(html);

// outputs: <div><p></p></div>
```

As you can see, the HTML characters of the text content of the `div` tag aren't escaped properly. This isn't consistent with `snabbdom`'s behavior and this is a security flaw: if anyone is using this library in production to render pages, they might be vulnerable to XSS attacks.

Issue #36 seems to be related.