### PR TITLE
Take boolean attributes into account

### DIFF
--- a/modules/props.js
+++ b/modules/props.js
@@ -33,6 +33,39 @@ var omit = [
   'tagName'
 ]
 
+// https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes
+var booleanAttributes = [
+  'disabled',
+  'visible',
+  'checked',
+  'readonly',
+  'required',
+  'allowfullscreen',
+  'autofocus',
+  'autoplay',
+  'compact',
+  'controls',
+  'default',
+  'formnovalidate',
+  'hidden',
+  'ismap',
+  'itemscope',
+  'loop',
+  'multiple',
+  'muted',
+  'noresize',
+  'noshade',
+  'novalidate',
+  'nowrap',
+  'open',
+  'reversed',
+  'seamless',
+  'selected',
+  'sortable',
+  'truespeed',
+  'typemustmatch'
+]
+
 // data.props
 
 module.exports = function propsModule (vnode, attributes) {
@@ -49,6 +82,13 @@ module.exports = function propsModule (vnode, attributes) {
       key = 'class'
     }
 
-    attributes.set(key.toLowerCase(), escape(value))
+    var lkey = key.toLowerCase()
+    if (~booleanAttributes.indexOf(lkey)) {
+      if (value) { // set attr only when truthy
+        attributes.set(lkey, lkey)
+      }
+    } else {
+      attributes.set(lkey, escape(value))
+    }
   })
 }

--- a/test/index.js
+++ b/test/index.js
@@ -319,3 +319,19 @@ test('Empty string in children', function (t) {
 
   t.end()
 })
+
+test('Boolean attributes', function (t) {
+  // truthy case
+  var vnode = h('input', { props: { type: 'checkbox', checked: true } })
+  var htmlString = '<input type="checkbox" checked="checked">'
+
+  t.equal(toHTML(vnode), htmlString)
+
+  // falsy case
+  vnode = h('input', { props: { type: 'checkbox', checked: false } })
+  htmlString = '<input type="checkbox">'
+
+  t.equal(toHTML(vnode), htmlString)
+
+  t.end()
+})


### PR DESCRIPTION
Updated `modules/props.js` so that it will take [boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes) into account.
(`false` values for such attributes shouldn't be interpreted as `"false"`)