### PR TITLE
Remove unneeded libs

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,5 +1,5 @@
 
-var escape = require('lodash.escape')
+var escape = require('./util/escape')
 var parseSelector = require('parse-sel')
 var VOID_ELEMENTS = require('./elements').VOID
 var CONTAINER_ELEMENTS = require('./elements').CONTAINER

--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -1,5 +1,5 @@
 
-var escape = require('lodash.escape')
+var escape = require('../util/escape')
 
 // data.attrs
 

--- a/modules/attributes.js
+++ b/modules/attributes.js
@@ -1,5 +1,4 @@
 
-var forOwn = require('lodash.forown')
 var escape = require('lodash.escape')
 
 // data.attrs
@@ -7,7 +6,7 @@ var escape = require('lodash.escape')
 module.exports = function attrsModule (vnode, attributes) {
   var attrs = vnode.data.attrs || {}
 
-  forOwn(attrs, function (value, key) {
+  Object.entries(attrs).forEach(function ([key, value]) {
     attributes.set(key, escape(value))
   })
 }

--- a/modules/class.js
+++ b/modules/class.js
@@ -1,6 +1,4 @@
 
-var forOwn = require('lodash.forown')
-
 // data.class
 
 module.exports = function classModule (vnode, attributes) {
@@ -11,7 +9,7 @@ module.exports = function classModule (vnode, attributes) {
   var existing = attributes.get('class')
   existing = existing.length > 0 ? existing.split(' ') : []
 
-  forOwn(classes, function (value, key) {
+  Object.entries(classes).forEach(function ([key, value]) {
     if (value) {
       _add.push(key)
     } else {

--- a/modules/class.js
+++ b/modules/class.js
@@ -18,7 +18,7 @@ module.exports = function classModule (vnode, attributes) {
   })
 
   values = [...new Set(existing.concat(_add))]
-    .filter(value => _remove.indexOf(value) < 0)
+    .filter(function (value) { return _remove.indexOf(value) < 0 })
 
   if (values.length) {
     attributes.set('class', values.join(' '))

--- a/modules/class.js
+++ b/modules/class.js
@@ -1,7 +1,5 @@
 
 var forOwn = require('lodash.forown')
-var remove = require('lodash.remove')
-var uniq = require('lodash.uniq')
 
 // data.class
 
@@ -21,9 +19,8 @@ module.exports = function classModule (vnode, attributes) {
     }
   })
 
-  values = remove(uniq(existing.concat(_add)), function (value) {
-    return _remove.indexOf(value) < 0
-  })
+  values = [...new Set(existing.concat(_add))]
+    .filter(value => _remove.indexOf(value) < 0)
 
   if (values.length) {
     attributes.set('class', values.join(' '))

--- a/modules/dataset.js
+++ b/modules/dataset.js
@@ -1,5 +1,4 @@
 
-var forOwn = require('lodash.forown')
 var escape = require('lodash.escape')
 
 // data.dataset
@@ -7,7 +6,7 @@ var escape = require('lodash.escape')
 module.exports = function datasetModule (vnode, attributes) {
   var dataset = vnode.data.dataset || {}
 
-  forOwn(dataset, function (value, key) {
+  Object.entries(dataset).forEach(function ([key, value]) {
     attributes.set(`data-${key}`, escape(value))
   })
 }

--- a/modules/dataset.js
+++ b/modules/dataset.js
@@ -1,5 +1,5 @@
 
-var escape = require('lodash.escape')
+var escape = require('../util/escape')
 
 // data.dataset
 

--- a/modules/props.js
+++ b/modules/props.js
@@ -1,5 +1,5 @@
 
-var escape = require('lodash.escape')
+var escape = require('../util/escape')
 
 // https://developer.mozilla.org/en-US/docs/Web/API/element
 var omit = [

--- a/modules/props.js
+++ b/modules/props.js
@@ -1,5 +1,4 @@
 
-var forOwn = require('lodash.forown')
 var escape = require('lodash.escape')
 
 // https://developer.mozilla.org/en-US/docs/Web/API/element
@@ -71,7 +70,7 @@ var booleanAttributes = [
 module.exports = function propsModule (vnode, attributes) {
   var props = vnode.data.props || {}
 
-  forOwn(props, function (value, key) {
+  Object.entries(props).forEach(function ([key, value]) {
     if (omit.indexOf(key) > -1) {
       return
     }

--- a/modules/style.js
+++ b/modules/style.js
@@ -1,6 +1,6 @@
 
 var assign = require('object-assign')
-var escape = require('lodash.escape')
+var escape = require('../util/escape')
 var kebabCase = require('lodash.kebabcase')
 
 // data.style

--- a/modules/style.js
+++ b/modules/style.js
@@ -1,6 +1,5 @@
 
 var assign = require('object-assign')
-var forOwn = require('lodash.forown')
 var escape = require('lodash.escape')
 var kebabCase = require('lodash.kebabcase')
 
@@ -15,7 +14,7 @@ module.exports = function styleModule (vnode, attributes) {
     assign(style, style.delayed)
   }
 
-  forOwn(style, function (value, key) {
+  Object.entries(style).forEach(function ([key, value]) {
     // omit hook objects
     if (typeof value === 'string' || typeof value === 'number') {
       var kebabKey = kebabCase(key)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "lodash.escape": "^4.0.1",
-        "lodash.forown": "^4.4.0",
         "lodash.kebabcase": "^4.1.1",
         "object-assign": "^4.1.0",
         "parse-sel": "^1.0.0"
@@ -2438,11 +2437,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
-    },
-    "node_modules/lodash.forown": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-4.4.0.tgz",
-      "integrity": "sha1-hRFc8E9z75ZuztUlEdOJPMRmg68="
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
@@ -6132,11 +6126,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
       "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
-    },
-    "lodash.forown": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-4.4.0.tgz",
-      "integrity": "sha1-hRFc8E9z75ZuztUlEdOJPMRmg68="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "snabbdom-to-html",
       "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
         "lodash.escape": "^4.0.1",
         "lodash.forown": "^4.4.0",
         "lodash.kebabcase": "^4.1.1",
-        "lodash.remove": "^4.7.0",
-        "lodash.uniq": "^4.5.0",
         "object-assign": "^4.1.0",
         "parse-sel": "^1.0.0"
       },
@@ -2455,16 +2454,6 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
-    },
-    "node_modules/lodash.remove": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.remove/-/lodash.remove-4.7.0.tgz",
-      "integrity": "sha1-8x0x58OaBpDVB07A02JxYjNO5iY="
-    },
-    "node_modules/lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6159,16 +6148,6 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
-    },
-    "lodash.remove": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.remove/-/lodash.remove-4.7.0.tgz",
-      "integrity": "sha1-8x0x58OaBpDVB07A02JxYjNO5iY="
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
-        "lodash.escape": "^4.0.1",
         "lodash.kebabcase": "^4.1.1",
         "object-assign": "^4.1.0",
         "parse-sel": "^1.0.0"
@@ -2432,11 +2431,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "node_modules/lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
@@ -6121,11 +6115,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "lodash.escape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "homepage": "https://github.com/acstll/snabbdom-to-html#readme",
   "dependencies": {
     "lodash.escape": "^4.0.1",
-    "lodash.forown": "^4.4.0",
     "lodash.kebabcase": "^4.1.1",
     "object-assign": "^4.1.0",
     "parse-sel": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/acstll/snabbdom-to-html#readme",
   "dependencies": {
-    "lodash.escape": "^4.0.1",
     "lodash.kebabcase": "^4.1.1",
     "object-assign": "^4.1.0",
     "parse-sel": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "lodash.escape": "^4.0.1",
     "lodash.forown": "^4.4.0",
     "lodash.kebabcase": "^4.1.1",
-    "lodash.remove": "^4.7.0",
-    "lodash.uniq": "^4.5.0",
     "object-assign": "^4.1.0",
     "parse-sel": "^1.0.0"
   },

--- a/util/escape.js
+++ b/util/escape.js
@@ -1,0 +1,15 @@
+
+var escapes = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&apos;',
+  '`': '&#96;'
+}
+
+var re = new RegExp(`[${Object.keys(escapes).join('')}]`, 'g')
+
+module.exports = function escape (value) {
+  return ('' + value).replace(re, function (s) { return escapes[s] })
+}


### PR DESCRIPTION
This would change compatibility to later Node version. (Or, not really, because of `export` in `snabbdom`)

- [`Object.entries`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries): Node 7.0
- [`Destructuring assignment`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment): Node 6.0

---

The use of `export` in `snabbdom` seems to first work since **Node 8.0.0** (I checked this on `master` branch)